### PR TITLE
Pricing: remove Premium plan term.

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -10,7 +10,7 @@ image: site_assets/img/social.jpg
     <div class="page__section-wrapper">
 
       <div class="page__intro">
-        <h1>Available two ways.</h1>
+        <h1>Available now.</h1>
       </div>
 
       <div class="pricing__plans">
@@ -36,7 +36,7 @@ image: site_assets/img/social.jpg
           </div>
         </div>
         <div class="pricing__plans__premium">
-          <h2><strong>Premium</strong> plan</h2>
+          <h2>To go beyond Freemium</h2>
           <h3>All the features for businesses without limitation, coupled with extra support.</h3>
           <ul class="pricing__features">
             <li>Use shared public agents</li>


### PR DESCRIPTION
**Description**

On pricing page:

1/ Replace "Available two ways" by "Available now"
2/ Replace "Premium Plan" by "To go beyond Freemium"